### PR TITLE
Add annotations future import to instruments

### DIFF
--- a/qcodes_qick/instruments.py
+++ b/qcodes_qick/instruments.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from qcodes import ChannelTuple, Instrument
 
 import qick


### PR DESCRIPTION
This fixes Python 3.8 compatibility. Why was this not caught by the CI? It shows up with just `import qcodes_qick` in Python 3.8.