### PR TITLE
Revert "Fixed attribute name to avoid conflict with keyword `type`"

### DIFF
--- a/qcodes_qick/channels_v2.py
+++ b/qcodes_qick/channels_v2.py
@@ -33,7 +33,7 @@ class DacChannel(InstrumentChannel, ABC):
         super().__init__(parent, name)
         self.channel_num = channel_num
 
-        self.chan_type = Parameter(
+        self.type = Parameter(
             name="type",
             instrument=self,
             label="DAC type",
@@ -216,7 +216,7 @@ class AdcChannel(InstrumentChannel):
         self.channel_num = channel_num
         config = parent.soccfg["readouts"][channel_num]
 
-        self.chan_type = Parameter(
+        self.type = Parameter(
             name="type",
             instrument=self,
             label="ADC type",


### PR DESCRIPTION
Reverts aalto-qcd/qcodes_qick#31