### PR TITLE
fix deprecation warnings

### DIFF
--- a/qcodes_qick/parameters_v2.py
+++ b/qcodes_qick/parameters_v2.py
@@ -60,8 +60,8 @@ class SweepableParameter(Parameter):
             validator = SweepableNumbers(min_value, max_value)
 
         super().__init__(
-            name,
-            instrument,
+            name=name,
+            instrument=instrument,
             label=label,
             unit=unit,
             vals=validator,


### PR DESCRIPTION
This commit explicits keyword arguments over positional due to deprecation warnings from QCoDeS.