### PR TITLE
Update ruff github actions

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Ruff linter
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@v3
       - name: Run Ruff formatter
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@v3
         with:
           args: "format --check"
 


### PR DESCRIPTION
This removes the archived chartboost/ruff-action and adds the official action from astral-sh.