### PR TITLE
add RuntimeError if `macro_list` is empty

### DIFF
--- a/qcodes_qick/instrument_v2.py
+++ b/qcodes_qick/instrument_v2.py
@@ -213,6 +213,12 @@ class QickInstrument(Instrument):
         state_classifier: Callable[[np.ndarray], np.ndarray] | None = None,
         save_shots_as_npy: bool = False,
     ) -> int:
+        if len(self.macro_list) == 0:
+            msg = (
+                "`macro_list` is empty. Please define the sequence with"
+                "`QickInstrument.set_macro_list([...]) before running the measurement."
+            )
+            raise RuntimeError(msg)
         if acquisition_mode in [
             "accumulated geometric median",
             "accumulated shots",
@@ -277,7 +283,12 @@ class QickInstrument(Instrument):
         adc_channel_nums = program.ro_chs.keys()
         reads_per_shot = [ro["trigs"] for ro in program.ro_chs.values()]
         assert len(adc_channel_nums) == len(reads_per_shot)
-        assert sum(reads_per_shot) > 0
+        if sum(reads_per_shot) == 0:
+            msg = (
+                "The macro_list contains no readout triggers, so no data is acquired."
+                "Include a readout macro with `QickInstrument.set_macro_list()."
+            )
+            raise RuntimeError(msg)
 
         # create and register the parameters representing the acquired data
         result_parameters = []

--- a/qcodes_qick/instrument_v2.py
+++ b/qcodes_qick/instrument_v2.py
@@ -216,7 +216,7 @@ class QickInstrument(Instrument):
         if len(self.macro_list) == 0:
             msg = (
                 "`macro_list` is empty. Please define the sequence with"
-                "`QickInstrument.set_macro_list([...]) before running the measurement."
+                "`QickInstrument.set_macro_list([...])` before running the measurement."
             )
             raise RuntimeError(msg)
         if acquisition_mode in [
@@ -286,7 +286,7 @@ class QickInstrument(Instrument):
         if sum(reads_per_shot) == 0:
             msg = (
                 "The macro_list contains no readout triggers, so no data is acquired."
-                "Include a readout macro with `QickInstrument.set_macro_list()."
+                "Include a readout macro with `QickInstrument.set_macro_list()`."
             )
             raise RuntimeError(msg)
 


### PR DESCRIPTION
Before this `assert sum(reads_per_shot) > 0` would fail providing no context to the user. This commit fixes that.